### PR TITLE
chore: サンプルデータ用DBファイルを追跡対象に設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,10 @@ next-env.d.ts
 # OS
 Thumbs.db
 
-# Database
-*.db
-*.sqlite
-*.sqlite3
+# Database (sample data is tracked for demo purposes)
+# *.db
+# *.sqlite
+# *.sqlite3
 
 # Logs
 logs/


### PR DESCRIPTION
.gitignoreのデータベースファイル除外設定をコメントアウトし、
サンプル/デモ用のDBファイルをGit管理下で維持できるように変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)